### PR TITLE
Non-zero exit code on status if dory isn't totally "up"

### DIFF
--- a/bin/dory
+++ b/bin/dory
@@ -363,12 +363,14 @@ class DoryBin < Thor
   def exec_status(_options)
     puts "Reading settings file at '#{Dory::Config.filename}'".green if options[:verbose]
     settings = Dory::Config.settings
+    exit_code = 0
 
     if Dory::Proxy.running?
       puts "[*] Nginx proxy:  Running as docker container #{Dory::Proxy.container_name}".green
     elsif !nginx_proxy_enabled?(settings)
       puts "[*] Nginx proxy is disabled in config file".yellow
     else
+      exit_code = 3
       puts "[*] Nginx proxy is not running".red
     end
 
@@ -377,6 +379,7 @@ class DoryBin < Thor
     elsif !dnsmasq_enabled?(settings)
       puts "[*] Dnsmasq is disabled in config file".yellow
     else
+      exit_code = 3
       puts "[*] Dnsmasq is not running".red
     end
 
@@ -385,8 +388,11 @@ class DoryBin < Thor
     elsif !resolv_enabled?(settings)
       puts "[*] Resolv is disabled in config file".yellow
     else
+      exit_code = 3
       puts "[*] Resolv is not configured".red
     end
+
+    exit exit_code
   end
 
   def exec_down(options, services)
@@ -518,6 +524,7 @@ end
 
 aliases = {
   'start'  => 'up',
+  'ps'     => 'status',
   'stop'   => 'down',
   'update' => 'upgrade'
 }


### PR DESCRIPTION
Alias ps=>status for docker-like behavior hidden in here as well.

I welcome feedback on the error code pattern.  I wanted to make it a
"means the number of services down" but figured it didn't actually
matter as long as it was easier to script against, for my purposes.