### PR TITLE
Add support for resolvconf systems

### DIFF
--- a/lib/dory/resolv.rb
+++ b/lib/dory/resolv.rb
@@ -1,9 +1,11 @@
 require 'colorize'
+require 'pathname'
 
 module Dory
   module Resolv
     def self.get_module
       return Dory::Resolv::Macos if Os.macos?
+      return Dory::Resolv::LinuxResolvconf if self.resolvconf?
       Dory::Resolv::Linux
     end
 
@@ -21,6 +23,11 @@ module Dory
 
     def self.clean
       self.get_module.clean
+    end
+
+    def self.resolvconf?
+      Pathname.new('/etc/resolv.conf').realpath.to_s ==
+        '/run/resolvconf/resolv.conf'
     end
   end
 end

--- a/lib/dory/resolv/linux_resolvconf.rb
+++ b/lib/dory/resolv/linux_resolvconf.rb
@@ -1,0 +1,27 @@
+module Dory
+  module Resolv
+    module LinuxResolvconf
+      def self.file_nameserver_line
+        Linux.file_nameserver_line
+      end
+
+      def self.nameserver_contents
+        Linux.nameserver_contents
+      end
+
+      def self.has_our_nameserver?
+        Linux.has_our_nameserver?
+      end
+
+      def self.configure
+        puts 'Requesting sudo to run resolvconf'.green
+        Bash.run_command("echo -e '#{self.nameserver_contents}' | sudo resolvconf -a lo.dory")
+      end
+
+      def self.clean
+        puts 'Requesting sudo to run resolvconf'.green
+        Bash.run_command("sudo resolvconf -d lo.dory")
+      end
+    end
+  end
+end

--- a/spec/lib/resolv/linux_resolvconf_spec.rb
+++ b/spec/lib/resolv/linux_resolvconf_spec.rb
@@ -1,0 +1,41 @@
+require 'rspec'
+
+RSpec.describe Dory::Resolv::LinuxResolvconf do
+  describe '.file_nameserver_line' do
+    it 'delegates to the linux module'
+  end
+
+  describe '.nameserver_contents' do
+    it 'delegates to the linux module'
+  end
+
+  describe '.has_our_nameserver?' do
+    it 'delegates to the linux module'
+  end
+
+  describe '.configure' do
+    before do
+      allow(Dory::Bash).to receive(:run_command)
+    end
+
+    it 'runs resolvconf' do
+      Dory::Resolv::LinuxResolvconf.configure
+      expect(Dory::Bash).to have_received(:run_command).with(
+        "echo -e 'nameserver 127.0.0.1  # added by dory' | sudo resolvconf -a lo.dory"
+      )
+    end
+  end
+
+  describe '.clean' do
+    before do
+      allow(Dory::Bash).to receive(:run_command)
+    end
+
+    it 'runs resolvconf' do
+      Dory::Resolv::LinuxResolvconf.clean
+      expect(Dory::Bash).to have_received(:run_command).with(
+        'sudo resolvconf -d lo.dory'
+      )
+    end
+  end
+end

--- a/spec/lib/resolv/macos_spec.rb
+++ b/spec/lib/resolv/macos_spec.rb
@@ -14,13 +14,11 @@ RSpec.describe Dory::Resolv::Macos do
     ->() { allow(Dory::Resolv::Macos).to receive(:resolv_files).and_call_original }
   end
 
-  let(:set_macos) do
-    ->() do
-      allow(Dory::Os).to receive(:macos?){ true }
-      allow(Dory::Os).to receive(:ubuntu?){ false }
-      allow(Dory::Os).to receive(:fedora?){ false }
-      allow(Dory::Os).to receive(:arch?){ false }
-    end
+  let!(:set_macos) do
+    allow(Dory::Os).to receive(:macos?){ true }
+    allow(Dory::Os).to receive(:ubuntu?){ false }
+    allow(Dory::Os).to receive(:fedora?){ false }
+    allow(Dory::Os).to receive(:arch?){ false }
   end
 
   before :each do

--- a/spec/lib/resolv_spec.rb
+++ b/spec/lib/resolv_spec.rb
@@ -1,5 +1,11 @@
 RSpec.describe Dory::Resolv do
-  let(:modules) { [Dory::Resolv::Linux, Dory::Resolv::Macos] }
+  let(:modules) do
+    [
+      Dory::Resolv::Linux,
+      Dory::Resolv::LinuxResolvconf,
+      Dory::Resolv::Macos
+    ]
+  end
   let(:methods) do
     %i[has_our_nameserver? configure clean file_nameserver_line]
   end
@@ -7,6 +13,7 @@ RSpec.describe Dory::Resolv do
   it 'calls the versions based on platform' do
     modules.each do |platform|
       allow(Dory::Os).to receive(:macos?) { platform == Dory::Resolv::Macos }
+      allow(Dory::Resolv).to receive(:resolvconf?) { platform == Dory::Resolv::LinuxResolvconf }
       methods.each do |m|
         allow(platform).to receive(m)
         Dory::Resolv.send(m)


### PR DESCRIPTION
I'm trying to support a developer running on Elementary OS.  That distro uses resolvconf out of the box and it wipes the changes that dory makes within a few seconds.  This PR works with resolvconf instead of fighting with it.