### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dory (0.6.4)
+    dory (1.0.1)
       activesupport (~> 5.2)
       colorize (~> 0.8)
       ptools (~> 1.3)

--- a/lib/dory/version.rb
+++ b/lib/dory/version.rb
@@ -1,4 +1,4 @@
 module Dory
-  VERSION = '1.0.0'
-  DATE    = '2018-08-17'
+  VERSION = '1.0.1'
+  DATE    = '2018-08-22'
 end


### PR DESCRIPTION
Adds support for resolvconf on linux distros that use it (such as Linux
Mint)