### PR TITLE
Bump dinghy-http-proxy to 2.5.10

### DIFF
--- a/lib/dory/proxy.rb
+++ b/lib/dory/proxy.rb
@@ -8,7 +8,7 @@ module Dory
       setting = Dory::Config.settings[:dory][:nginx_proxy][:image]
       return setting if setting
       certs_dir && !certs_dir.empty? \
-        ? 'codekitchen/dinghy-http-proxy:2.5.9' \
+        ? 'codekitchen/dinghy-http-proxy:2.5.10' \
         : 'freedomben/dory-http-proxy:2.5.9.1'
     end
 


### PR DESCRIPTION
Version 2.5.9 og dinghy-http-proxy contained a broken path to the dhparam.pem file which broke the TLS support (https://github.com/codekitchen/dinghy-http-proxy/pull/41).

This PR bumps to 2.5.10 that has the fix.

Another approach would be to go with the more general 2.5 tag instead which seems to be be kept up to date as well (https://hub.docker.com/r/codekitchen/dinghy-http-proxy/tags)