### PR TITLE
Remove .dev examples and default config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,6 @@ dory:
     domains:               # array of domains that will be resolved to the specified address
       - domain: docker     # you can set '#' for a wilcard
         address: 127.0.0.1 # return for queries against the domain
-      - domain: dev
-        address: 127.0.0.1
     container_name: dory_dnsmasq
     port: 53  # port to listen for dns requests on.  must be 53 on linux. can be anything that's open on macos
     # kill_others: kill processes bound to the port we need (see previous setting 'port')
@@ -203,7 +201,7 @@ docker run -e VIRTUAL_HOST=myapp.docker  ...
 
 If you are using dinghy, but want to use dory to manage the proxy instead of dinghy's built-in stuff,
 this is now possible! (the use case for this that we ran into was multiple domain support.  For example,
-the dev wanted to have some containers accessible at `something.docker` and `another.dev`).  To accomplish this,
+the dev wanted to have some containers accessible at `something.docker`).  To accomplish this,
 you need to disable dinghy's proxy stuff (otherwise dinghy and dory will stomp on each other's resolv files):
 
 In your [`~/.dinghy/preferences.yml`](https://github.com/codekitchen/dinghy#preferences)
@@ -226,8 +224,6 @@ dory:
   dnsmasq:
     domains:
       - domain: docker
-        address: dinghy # instead of the default 127.0.0.1
-      - domain: dev
         address: dinghy # instead of the default 127.0.0.1
     ...
   resolv:

--- a/lib/dory/config.rb
+++ b/lib/dory/config.rb
@@ -41,8 +41,6 @@ module Dory
             domains:               # array of domains that will be resolved to the specified address
               - domain: docker     # you can set '#' for a wilcard
                 address: 127.0.0.1 # return for queries against the domain
-              - domain: dev
-                address: 127.0.0.1
             container_name: dory_dnsmasq
             port: 53  # port to listen for dns requests on.  must be 53 on linux. can be anything that's open on macos
             # kill_others: kill processes bound to the port we need (see previous setting 'port')

--- a/spec/bin/dory_spec.rb
+++ b/spec/bin/dory_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DoryBin do
   end
 
   def macos_resolv_filenames
-    %w[/tmp/resolver/docker /tmp/resolver/dev /tmp/resolver/dory]
+    %w[/tmp/resolver/docker /tmp/resolver/dory]
   end
 
   def linux_resolv_filename

--- a/spec/lib/resolv/macos_spec.rb
+++ b/spec/lib/resolv/macos_spec.rb
@@ -2,7 +2,7 @@ require 'rspec'
 
 RSpec.describe Dory::Resolv::Macos do
   let(:resolv_dir) { '/tmp/resolver' }
-  let(:resolv_files) { %w[docker dev dory] }
+  let(:resolv_files) { %w[docker dory] }
   let(:system_resolv_file) { '/tmp/resolv.conf' }
   let(:filenames) { %w[/tmp/resolver/docker /tmp/resolver/dev /tmp/resolver/dory] }
 


### PR DESCRIPTION
.dev is an actual top-level domain, used by several
websites by now.
If uses .dev with Dory, they will not be able to
access real websites using .dev without SSL
certificate errors.