### PR TITLE
use the 1.0 version of thor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       activesupport (>= 5.2, < 7.0)
       colorize (~> 0.8)
       ptools (~> 1.3)
-      thor (~> 0.20)
+      thor (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -63,7 +63,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    thor (0.20.3)
+    thor (1.0.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.4.0)

--- a/dory.gemspec
+++ b/dory.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.executables << 'dory'
 
   s.add_runtime_dependency 'colorize', '~> 0.8'
-  s.add_runtime_dependency 'thor', '~> 0.20'
+  s.add_runtime_dependency 'thor', '~> 1.0'
   s.add_runtime_dependency 'ptools', '~> 1.3'
   s.add_runtime_dependency 'activesupport', '>= 5.2', '< 7.0'
 


### PR DESCRIPTION
I was trying to use `gem2deb` to build a debian package of dory, but debian's `ruby-thor` package is at `1.0.1` 